### PR TITLE
Remove the need for internal buffer, only allow aligned operations

### DIFF
--- a/AT45BlockDevice.h
+++ b/AT45BlockDevice.h
@@ -13,28 +13,33 @@
 #define at45_debug(...) debug(__VA_ARGS__)
 #endif
 
-enum at45_bd_error {
-    BD_ERROR_NO_MEMORY          = -4002,
-    BD_ERROR_NOT_INITIALIZED    = -4003,
-};
-
 class AT45BlockDevice : public BlockDevice {
 public:
-    AT45BlockDevice() : spi(SPI_MOSI, SPI_MISO, SPI_SCK, SPI_NSS), at45(&spi, SPI_NSS) {
+
+    /**
+     * Initialize a block device on an AT45 SPI flash chip.
+     * Size and number of pages are determined directly from the chip itself.
+     *
+     * @param mosi SPI MOSI pin
+     * @param miso SPI MISO pin
+     * @param sck  SPI SCK pin
+     * @param nss  SPI chip-select pin
+     */
+    AT45BlockDevice(PinName mosi, PinName miso, PinName sck, PinName nss)
+        : spi(mosi, miso, sck, nss), at45(&spi, nss)
+    {
         pagesize = at45.pagesize();
         totalsize = pagesize * at45.pages();
     }
 
     virtual ~AT45BlockDevice() {
-        if (pagebuffer) free(pagebuffer);
     }
 
+    /** Initialize a block device
+     *
+     *  @return         0 on success or a negative error code on failure
+     */
     virtual int init() {
-        pagebuffer = (char*)calloc(pagesize, 1);
-        if (!pagebuffer) {
-            return BD_ERROR_NO_MEMORY;
-        }
-
         return BD_ERROR_OK;
     }
 
@@ -44,121 +49,104 @@ public:
         return BD_ERROR_OK;
     }
 
+    /** Program blocks to a block device
+     *
+     *  The blocks must have been erased prior to being programmed
+     *
+     *  @param buffer   Buffer of data to write to blocks
+     *  @param addr     Address of block to begin writing to
+     *  @param size     Size to write in bytes, must be a multiple of program block size
+     *  @return         0 on success, negative error code on failure
+     */
     virtual int program(const void *a_buffer, bd_addr_t addr, bd_size_t size) {
-        if (!pagebuffer) return BD_ERROR_NOT_INITIALIZED;
+        MBED_ASSERT(is_valid_read(addr, size));
 
         // Q: a 'global' pagebuffer makes this code not thread-safe...
         // is this a problem? don't really wanna malloc/free in every call
 
-        char *buffer = (char*)a_buffer;
-
         at45_debug("[AT45] write addr=%lu size=%d\n", addr, size);
 
-        // find the page
-        size_t bytes_left = size;
-        while (bytes_left > 0) {
-            uint32_t page = addr / pagesize; // this gets auto-rounded
-            uint32_t offset = addr % pagesize; // offset from the start of the pagebuffer
-            uint32_t length = pagesize - offset; // number of bytes to write in this pagebuffer
-            if (length > bytes_left) length = bytes_left; // don't overflow
+        uint32_t page = addr / pagesize; // this gets auto-rounded
 
-            at45_debug("[AT45] writing to page=%lu, offset=%lu, length=%lu\n", page, offset, length);
+        at45_debug("[AT45] writing to page=%lu\n", page, offset, length);
 
-            int r;
-
-            // retrieve the page first, as we don't want to overwrite the full page
-            r = at45.read_page(pagebuffer, page);
-            if (r != 0) return r;
-
-            // at45_debug("[AT45] pagebuffer of page %d is:\n", page);
-            // for (size_t ix = 0; ix < pagesize; ix++) {
-                // at45_debug("%02x ", pagebuffer[ix]);
-            // }
-            // at45_debug("\n");
-
-            // now memcpy to the pagebuffer
-            memcpy(pagebuffer + offset, buffer, length);
-
-            // at45_debug("pagebuffer after memcpy is:\n", page);
-            // for (size_t ix = 0; ix < pagesize; ix++) {
-                // at45_debug("%02x ", pagebuffer[ix]);
-            // }
-            // at45_debug("\n");
-
-            // and write back
-            r = at45.write_page(pagebuffer, page);
-            if (r != 0) return r;
-
-            // change the page
-            bytes_left -= length;
-            addr += length;
-            buffer += length;
-        }
+        int r = at45.write_page((char*)a_buffer, page);
+        if (r != 0) return r;
 
         return BD_ERROR_OK;
     }
 
+    /** Read blocks from a block device
+     *
+     *  @param buffer   Buffer to read blocks into
+     *  @param addr     Address of block to begin reading from
+     *  @param size     Size to read in bytes, must be a multiple of read block size
+     *  @return         0 on success, negative error code on failure
+     */
     virtual int read(void *a_buffer, bd_addr_t addr, bd_size_t size) {
-        if (!pagebuffer) return BD_ERROR_NOT_INITIALIZED;
+        MBED_ASSERT(is_valid_program(addr, size));
 
         at45_debug("[AT45] read addr=%lu size=%d\n", addr, size);
 
-        char *buffer = (char*)a_buffer;
+        uint32_t page = addr / pagesize; // this gets auto-rounded
 
-        size_t bytes_left = size;
-        while (bytes_left > 0) {
-            uint32_t page = addr / pagesize; // this gets auto-rounded
-            uint32_t offset = addr % pagesize; // offset from the start of the pagebuffer
-            uint32_t length = pagesize - offset; // number of bytes to read in this pagebuffer
-            if (length > bytes_left) length = bytes_left; // don't overflow
+        at45_debug("[AT45] Reading from page=%lu\n", page);
 
-            at45_debug("[AT45] Reading from page=%lu, offset=%lu, length=%lu\n", page, offset, length);
-
-            int r = at45.read_page(pagebuffer, page);
-            if (r != 0) return r;
-
-            // copy into the provided buffer
-            memcpy(buffer, pagebuffer + offset, length);
-
-            // change the page
-            bytes_left -= length;
-            addr += length;
-            buffer += length;
-        }
+        int r = at45.read_page((char*)a_buffer, page);
+        if (r != 0) return r;
 
         return BD_ERROR_OK;
     }
 
+    /** Erase blocks on a block device
+     *
+     *  The state of an erased block is undefined until it has been programmed
+     *
+     *  @param addr     Address of block to begin erasing
+     *  @param size     Size to erase in bytes, must be a multiple of erase block size
+     *  @return         0 on success, negative error code on failure
+     */
     virtual int erase(bd_addr_t addr, bd_size_t size) {
-        if (!pagebuffer) return BD_ERROR_NOT_INITIALIZED;
+        MBED_ASSERT(is_valid_erase(addr, size));
 
         at45_debug("[AT45] erase addr=%lu size=%d\n", addr, size);
 
-        uint32_t start_page = addr / pagesize; // this gets auto-rounded
-        uint32_t end_page = (addr + size) / pagesize;
+        uint32_t page = addr / pagesize; // this gets auto-rounded
 
-        memset(pagebuffer, 0xff, pagesize);
-
-        for (size_t ix = start_page; ix <= end_page; ix++) {
-            int r = at45.write_page(pagebuffer, ix);
-            if (r != 0) return r;
-        }
+        // why is this marked as void??
+        at45.page_erase(page);
 
         return BD_ERROR_OK;
     }
 
+    /** Get the size of a readable block
+     *
+     *  @return         Size of a readable block in bytes
+     */
     virtual bd_size_t get_read_size() const {
         return pagesize;
     }
 
+    /** Get the size of a programmable block
+     *
+     *  @return         Size of a programmable block in bytes
+     */
     virtual bd_size_t get_program_size() const {
         return pagesize;
     }
 
+    /** Get the size of an erasable block
+     *
+     *  @return         Size of an erasable block in bytes
+     */
     virtual bd_size_t get_erase_size() const {
         return pagesize;
     }
 
+    /** Get the total size of the underlying device
+     *
+     *  @return         Size of the underlying device in bytes
+     */
     virtual bd_size_t size() const {
         return totalsize;
     }
@@ -168,7 +156,6 @@ private:
     AT45 at45;
     bd_size_t pagesize;
     bd_size_t totalsize;
-    char* pagebuffer;
 };
 
 #endif // _FRAGMENTATION_FLASH_AT45_H_

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,56 @@
+All files except crc.h and FragmentationMath.h
+----------------------------------------------
+
+Copyright 2017 ARM Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+========================================================================
+
+crc.h
+-----
+
+Copyright (c) 2012, Salvatore Sanfilippo <antirez at gmail dot com>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of Redis nor the names of its contributors may be used
+    to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+========================================================================
+
+FragmentationMath.h
+-------------------
+
+Copyright 2017 Semtech Inc.
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# AT45 Block Device
+
+Mbed OS 5 [BlockDevice](https://os.mbed.com/docs/latest/reference/blockdevice.html) driver for the AT45 SPI Dataflash chip. Based off [Steen Jørgensen's AT45 library](https://os.mbed.com/users/stjo2809/code/AT45/). You can use this driver together with the file system APIs in Mbed OS to mount a file system on your external flash, or just use the driver directly. Note that you can only do aligned operations on this block device.
+
+## Deinitialization
+
+Mbed OS does not have a way to destruct a SPI interface once created. This causes issues with the AT45 when initializing it multiple times, like in a bootloader and then in an application. For this a `DeconstructableSPI` interface is used in this library. If you call `deinit` on the block device it will automatically uninitialize the SPI interface. Do this before jumping to the main program from a bootloader.


### PR DESCRIPTION
According to Mbed OS BlockDevice spec only aligned operations are permitted.

Unaligned operations on any block device are now implemented in https://github.com/janjongboom/mbed-lorawan-frag-lib.